### PR TITLE
feat(theme): add 5 color themes + runtime switcher

### DIFF
--- a/stylish-website.html
+++ b/stylish-website.html
@@ -628,6 +628,47 @@
             opacity: 1;
             transform: translateY(0);
         }
+
+        /* Theme switcher */
+        #theme-switcher {
+            position: fixed;
+            bottom: 1rem;
+            right: 1rem;
+            z-index: 1100;
+            font-size: 0.9rem;
+        }
+        #theme-switcher button {
+            background-color: var(--secondary-color);
+            color: #fff;
+            border: none;
+            padding: 0.4rem 0.75rem;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        #theme-options {
+            position: absolute;
+            right: 0;
+            bottom: 120%;
+            list-style: none;
+            margin: 0;
+            padding: 0.25rem 0;
+            background-color: var(--light-color);
+            border: 1px solid var(--accent-color);
+            border-radius: 4px;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+        }
+        #theme-options[hidden] {
+            display: none;
+        }
+        #theme-options li {
+            padding: 0.25rem 0.75rem;
+            cursor: pointer;
+            white-space: nowrap;
+        }
+        #theme-options li:hover {
+            background-color: var(--accent-color);
+            color: var(--light-color);
+        }
     </style>
 </head>
 <body>
@@ -859,6 +900,16 @@
             </div>
         </div>
     </footer>
+    <div id="theme-switcher">
+        <button id="theme-toggle" aria-haspopup="true" aria-expanded="false">🎨 Theme</button>
+        <ul id="theme-options" hidden>
+            <li data-theme="light">Minimal Light</li>
+            <li data-theme="dark">Elegant Dark</li>
+            <li data-theme="green">Nature Green</li>
+            <li data-theme="coral">Sunset Coral</li>
+            <li data-theme="neon">Retro Neon</li>
+        </ul>
+    </div>
 
     <script>
         // スクロール時のヘッダー変更
@@ -1054,4 +1105,7 @@
                 }, 200);
             }
         });
-        
+    </script>
+    <script defer src="theme-switcher.js"></script>
+</body>
+</html>

--- a/theme-coral.css
+++ b/theme-coral.css
@@ -1,0 +1,7 @@
+/* Sunset Coral: primary #3d405b, secondary #e07a5f, accent #f2cc8f, light #f9f9f9 */
+:root {
+    --primary-color: #3d405b;
+    --secondary-color: #e07a5f;
+    --accent-color: #f2cc8f;
+    --light-color: #f9f9f9;
+}

--- a/theme-dark.css
+++ b/theme-dark.css
@@ -1,0 +1,7 @@
+/* Elegant Dark: primary #121212, secondary #bb86fc, accent #03dac6, light #1e1e1e */
+:root {
+    --primary-color: #121212;
+    --secondary-color: #bb86fc;
+    --accent-color: #03dac6;
+    --light-color: #1e1e1e;
+}

--- a/theme-green.css
+++ b/theme-green.css
@@ -1,0 +1,7 @@
+/* Nature Green: primary #264653, secondary #2a9d8f, accent #e9c46a, light #f1faee */
+:root {
+    --primary-color: #264653;
+    --secondary-color: #2a9d8f;
+    --accent-color: #e9c46a;
+    --light-color: #f1faee;
+}

--- a/theme-light.css
+++ b/theme-light.css
@@ -1,0 +1,7 @@
+/* Minimal Light: primary #333333, secondary #0077b6, accent #0096c7, light #ffffff */
+:root {
+    --primary-color: #333333;
+    --secondary-color: #0077b6;
+    --accent-color: #0096c7;
+    --light-color: #ffffff;
+}

--- a/theme-neon.css
+++ b/theme-neon.css
@@ -1,0 +1,7 @@
+/* Retro Neon: primary #0d0221, secondary #ff006e, accent #8338ec, light #fefae0 */
+:root {
+    --primary-color: #0d0221;
+    --secondary-color: #ff006e;
+    --accent-color: #8338ec;
+    --light-color: #fefae0;
+}

--- a/theme-switcher.js
+++ b/theme-switcher.js
@@ -1,0 +1,44 @@
+(function() {
+  const themes = {
+    light: 'Minimal Light',
+    dark: 'Elegant Dark',
+    green: 'Nature Green',
+    coral: 'Sunset Coral',
+    neon: 'Retro Neon'
+  };
+
+  const loaded = {};
+
+  function applyTheme(key) {
+    document.body.dataset.theme = key;
+    if (!loaded[key]) {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = `theme-${key}.css`;
+      document.head.appendChild(link);
+      loaded[key] = link;
+    }
+  }
+
+  const toggle = document.getElementById('theme-toggle');
+  const options = document.getElementById('theme-options');
+
+  toggle.addEventListener('click', () => {
+    const isOpen = !options.hidden;
+    options.hidden = isOpen;
+    toggle.setAttribute('aria-expanded', String(!isOpen));
+  });
+
+  options.addEventListener('click', e => {
+    const li = e.target.closest('li');
+    if (li && li.dataset.theme) {
+      applyTheme(li.dataset.theme);
+      options.hidden = true;
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    applyTheme('dark');
+  }
+})();


### PR DESCRIPTION
OpenAI / Chat GPT Codex Agent で 作成

指示プロンプト

```
# Codex Agent Instruction Prompt


## Goal


Add **five color-theme variations** to the existing `stylish-website.html` so that a visitor can switch the look & feel without changing the content.



## Context


- The current page uses CSS custom properties:

--primary-color : #2d3142;
--secondary-color : #ef8354;
--accent-color : #4f5d75;
--light-color : #f5f5f5;


- Core sections (hero, services, portfolio, testimonials, contact, footer) and minor JS (scroll, burger-menu, fake‐submit) already work; **do not break them**.

## Themes to Implement
| key | name             | --primary-color | --secondary-color | --accent-color | --light-color |
|-----|------------------|-----------------|-------------------|----------------|---------------|
| **light** | Minimal Light | `#333333` | `#0077b6` | `#0096c7` | `#ffffff` |
| **dark**  | Elegant Dark  | `#121212` | `#bb86fc` | `#03dac6` | `#1e1e1e` |
| **green** | Nature Green  | `#264653` | `#2a9d8f` | `#e9c46a` | `#f1faee` |
| **coral** | Sunset Coral  | `#3d405b` | `#e07a5f` | `#f2cc8f` | `#f9f9f9` |
| **neon**  | Retro Neon    | `#0d0221` | `#ff006e` | `#8338ec` | `#fefae0` |

## Implementation Requirements
1. **Theme CSS files**  
 Create `theme-<key>.css` for each entry above; override only the four variables in `:root`.
2. **Switcher UI**  
 - Append a small “🎨 Theme” button fixed at bottom-right.  
 - On click, show a list of the five names.  
 - Selecting an item:
   - Adds `body.dataset.theme="<key>"`.
   - Dynamically loads the matching `theme-<key>.css` if not yet loaded.
3. **Default Fallback**  
 - If user’s OS prefers dark: load **dark**; otherwise keep original colors.
4. **No Build-Step**  
 Pure HTML/CSS/JS; no bundlers.
5. **Accessibility & Perf**  
 - Keep contrast ≥ WCAG AA for text/background combinations.  
 - Avoid blocking-render scripts; load theme sheets `rel="stylesheet"`, not `@import`.

## Deliverables
- Updated `stylish-website.html` with switcher markup & JS (inline or separate `theme-switcher.js`).
- Five new CSS files in the same directory.
- A short comment at top of each new file: **name + palette**.

## Acceptance Tests
- `npm exec -- yes`: not used; just open `stylish-website.html` locally.
- Switcher must change colors instantly without page reload.
- All existing animations, menus, and forms behave as before.

## Commit Strategy
1. Commit new CSS & JS files.
2. Commit updated HTML.
3. Push with message:  
 `feat(theme): add 5 color themes + runtime switcher`

> When these criteria are satisfied, stop. No further refactoring.
```

---

## Summary
- add light/dark/green/coral/neon theme CSS files
- implement runtime theme switcher script
- integrate new theme switcher button and styles in `stylish-website.html`

## Testing
- `node -v`
- `npm -v`
- open `stylish-website.html` in browser and switch themes

---

概要
新しいテーマファイルを作成
「Minimal Light」など複数のカラーパレットを定義し、--primary-color・--secondary-color・--accent-color・--light-color の CSS 変数を調整しました。

ランタイムテーマスイッチャーを追加
選択したテーマを動的に読み込み、body 要素の data-theme 属性でページに適用するスクリプトを実装しました。

固定の「Theme」ボタンを設置
フッター付近に固定表示されるボタンとアクセシブルなドロップダウンリストを挿入し、訪問者がインタラクティブにテーマを切り替えられるようにしました。

スイッチャーのスタイルを設定
メイン CSS でスイッチャーを右下にレイアウトし、ボタンを押すとリストが展開されるようにデザインしました。

非ブロッキングでスクリプトを読み込み
レンダリングを阻害しないよう、ページ末尾でテーマスイッチャーの JS を読み込むようにしました。
