### PR TITLE
Fix theme attribute application

### DIFF
--- a/theme-switcher.js
+++ b/theme-switcher.js
@@ -30,7 +30,9 @@
 
   function applyTheme(id){
     link.href = `themes/${id}.css`;
-    document.body.dataset.theme = id;
+    // Apply the theme attribute to the root element so that
+    // theme styles using :root[data-theme="..."] work correctly
+    document.documentElement.dataset.theme = id;
     localStorage.setItem('theme', id);
     contrastCheck();
   }


### PR DESCRIPTION
## Summary
- ensure theme data attribute is applied to the `<html>` element so the style rules match

## Testing
- `git log -1 --stat`

---

概要

ルート要素（<html> など）に data-theme 属性を設定し、:root[data-theme] を対象にした CSS ルールが正しく適用されるようにしてテーマ切り替えを修正しました。